### PR TITLE
New nearcore release mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Stake Wars Episode II: Return of the Validators
-July 22nd 2020 update: new sections in this README file!
+August 4th 2020 update: new `nearcore` release tags!
 
 Welcome to NEAR Stake Wars Episode II, Return of the Validators!
 

--- a/challenges/challenge001.md
+++ b/challenges/challenge001.md
@@ -34,7 +34,9 @@ Setup your validator node following the hardware requirements [here](https://doc
 Once your machine is ready, install [nearup](https://github.com/near/nearup). Nearup will provide simplified tools to run NEAR nodes, and is designed to help validators start their nodes, and developers who need a local RPC for their applications.
 
 Take your time to understand how to manually update [nearcore](https://github.com/nearprotocol/nearcore), and how to properly use the command `nearup betanet --nodocker --binary-path` (see below for contribution opportunities).
-To connect your node to `betanet` download and compile `nearcore` from its [beta branch](https://github.com/nearprotocol/nearcore/tree/beta).
+To connect your node to `betanet` download and compile the latest [nearcore release](https://github.com/nearprotocol/nearcore/releases):
+- BetaNet releases of nearcore are mapped with the tag `x.y.z-beta`
+- TestNet releases of nearcore are mapped with the tag `x.y.z-rc`
 
 **Heads up:** at this point, you have to decide the name of your staking pool!
 If your wallet is `nearkat.betanet`, you will have to choose a specific name for the staking pool, such as `nearkat_staking`. Since in the [step 3.2](challenge001.md#32-deploy-your-staking-pool) you will use the staking pool factory, your name will become `stakingPool_ID` + `stakehouse.betanet`.

--- a/challenges/challenge005.md
+++ b/challenges/challenge005.md
@@ -24,7 +24,9 @@ You may want to read [this article](https://hackernoon.com/understanding-the-bas
 3. Deploy the node
 
 ### 1.Build nearcore
-Subscribe to the [branch beta](https://github.com/nearprotocol/nearcore/tree/beta) of nearcore, and automatically build the artifact from the source code as soon as there's a new release.
+Subscribe to [Nearcore releases](https://github.com/nearprotocol/nearcore/releases), and automatically build the artifact from the source code as soon as there's a new version of the node. Every release is tagged as follows:
+- BetaNet releases of nearcore will be mapped with the tag `x.y.z-beta`
+- TestNet releases of nearcore will be mapped with the tag `x.y.z-rc`
 
 More information is available in the official documentation, in the [contribution section](https://docs.near.org/docs/contribution/nearcore) and in the [develop section](https://docs.near.org/docs/local-setup/running-testnet#compiling-and-running-official-node-without-docker)
 

--- a/updates.md
+++ b/updates.md
@@ -1,5 +1,9 @@
 # UPDATES
 
+## UPDATE August 3rd
+
+* Nearcore releases are not using anymore branching, so the instructions to build the binaries are different. Refer to https://github.com/nearprotocol/nearcore/releases to see the new release mapping.
+
 ## UPDATE July 22nd
 
 * Improved the [README.md](README.md) to clarify the role of challenges and add orientation of the files in this repository.


### PR DESCRIPTION
nearcore is not using anymore the `beta` and `stable` tree, leveraging the page at the address https://github.com/nearprotocol/nearcore/releases
I updated the challenges that were mentioning this now old process 